### PR TITLE
Update to be compatible with XMLS >=2.

### DIFF
--- a/cl-sendmail.asd
+++ b/cl-sendmail.asd
@@ -29,7 +29,7 @@
   :description "Common Lisp interface to use /usr/lib/sendmail for mail submission."
   :license "LGPL-2"
   :serial t
-  :version "0.6.1"
+  :version "0.6.2"                      ; bumped to reflect update for XMLS 2+ compatibility
   :depends-on (:cl-mime
 	       ;; the version from <http://mr.gy/maintenance/cl-qprint/>
 	       (:version :cl-qprint "0.9" )

--- a/xhtml.lisp
+++ b/xhtml.lisp
@@ -77,7 +77,8 @@ If you want to keep your XML structure intact make a copy first."
 
 (defmacro descend ()
   `(dolist (child (node-children tree))
-    (when (listp child)
+    (when #+xmls-nodes-are-structs (node-p child)
+          #-xmls-nodes-are-structs (listp child)
       (process-xml child))))
 
 (def-element-handler "html" (tree) (*xhtml-email-parser*)


### PR DESCRIPTION
These changes should preserve compatibility with older XMLS, but also permit operation with newer XMLS (where structures are used instead of lists for the parsed documents).
Bumped version number to 0.6.2.